### PR TITLE
Add support for custom texts in Chinese (`zh_cn.json`)

### DIFF
--- a/assets/minecraft/lang/zh_cn.json
+++ b/assets/minecraft/lang/zh_cn.json
@@ -1,12 +1,12 @@
 {
     "block.minecraft.smoker": "微波炉",
     "container.smoker": "微波炉",
-	"gui.recipebook.toggleRecipes.smokable": "仅显示可微波加热",
-	"soundCategory.music": "➡ 使用右边的滑块 ➡",
-	"soundCategory.record": "地图音乐",
-	"item.minecraft.baked_potato": "微波烤马铃薯",
-	"item.minecraft.spyglass": "间谍单目镜",
-	"item.minecraft.chainmail_helmet": "村民伪装",
-	"block.minecraft.deepslate_iron_ore": "核心石铁矿石",
-	"effect.minecraft.nausea": "眩晕"
+    "gui.recipebook.toggleRecipes.smokable": "仅显示可微波加热",
+    "soundCategory.music": "➡ 使用右边的滑块 ➡",
+    "soundCategory.record": "地图音乐",
+    "item.minecraft.baked_potato": "微波烤马铃薯",
+    "item.minecraft.spyglass": "间谍单目镜",
+    "item.minecraft.chainmail_helmet": "村民伪装",
+    "block.minecraft.deepslate_iron_ore": "核心岩铁矿石",
+    "effect.minecraft.nausea": "眩晕"
 }


### PR DESCRIPTION
This could help _potential_ chinese testers testing the map, as custom texts **won't** apply if the Minecraft language is not English (US).
You can merge it. This file doesn't affect English texts.
Close this pull request if you don't think this needs to be added!

_Note: This is a few part of the texts, most of the texts are in the datapack, and they cant be localized by adding another language file_